### PR TITLE
Numeric Protocols naming to match Swift3, methods with mutable semantics marked as deprecated, and their correct counterparts added

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -71,6 +71,13 @@ __mapped public class Array<T> : ISequence<T> => RemObjects.Elements.System.List
 		return sequence.array().mutableCopy()
 		#endif
 	}
+	
+	// our aggregate operations like .map, .filter will errase our collection type and yield ISequence
+	// so in order to have consistency with apple swift compiling
+	// we will do something like [String](fields.map(fieldNameWithRemovedPrivatePrefix)).someArrayFunc
+	public convenience init(_ sequence: ISequence<T>) {
+		return self.init(sequence: sequence)
+	}
 
 	public init(count: Int, repeatedValue: T) {
 		#if JAVA
@@ -372,7 +379,7 @@ __mapped public class Array<T> : ISequence<T> => RemObjects.Elements.System.List
 		return __mapped.Select(transform)
 		#endif
 	}
-
+	
 	public func reverse() -> ISequence<T> { // we deliberatey return a sequence, not an array, for efficiency and flexibility.
 		return (__mapped as! ISequence<T>).Reverse()
 	}
@@ -416,5 +423,16 @@ __mapped public class Array<T> : ISequence<T> => RemObjects.Elements.System.List
 		return __mapped.containsObject(item)
 		#endif
 	}
+	
+	public static func + <T>(lhs: Array<T>, rhs: ISequence<T>) -> Array<T> {
+	
+		let targetArray = [T](items: lhs)
+		for element in rhs {
+			targetArray.append(element)
+		}
+	
+		return targetArray
+	}
 
+	
 }

--- a/Source/Integer_Protocols.swift
+++ b/Source/Integer_Protocols.swift
@@ -26,6 +26,7 @@ public protocol BooleanType {
 	var boolValue: Bool { get }
 }
 
+public typealias IntegerArithmetic = IntegerArithmeticType
 public protocol IntegerArithmeticType : Comparable {
 	//class func addWithOverflow(lhs: Self, _ rhs: Self) -> (Self, overflow: Bool) //71481: Silver: can't use Self in tuple on static funcs i(in public protocols?)
 	//class func subtractWithOverflow(lhs: Self, _ rhs: Self) -> (Self, overflow: Bool)
@@ -41,6 +42,7 @@ public protocol IntegerArithmeticType : Comparable {
 	func toIntMax() -> IntMax
 }
 
+public typealias BitwiseOperations = BitwiseOperationsType
 public protocol BitwiseOperationsType {
 	//func &(_: Self, _: Self) -> Self //69825: Silver: two probs with operators in public protocols
 	func |(_: Self, _: Self) -> Self
@@ -59,6 +61,7 @@ public protocol BitwiseOperationsType {
 	//static/*class*/ var allZeros: Self { get }
 }
 
+public typealias SignedNumber = ISignedNumberType
 public typealias SignedNumberType = ISignedNumberType
 public protocol ISignedNumberType : Comparable, IntegerLiteralConvertible {
 	prefix func -(_ x: Self) -> Self
@@ -69,12 +72,14 @@ public protocol AbsoluteValuable : SignedNumberType {
 	static func abs(_ x: Self) -> Self
 }
 
+public typealias SignedInteger = ISignedIntegerType
 public typealias SignedIntegerType = ISignedIntegerType
 public protocol ISignedIntegerType {
 	init(_ value: IntMax)
 	func toIntMax() -> IntMax
 }
 
+public typealias UnsignedInteger = IUnsignedIntegerType
 public typealias UnsignedIntegerType = IUnsignedIntegerType
 public protocol IUnsignedIntegerType {
 	init(_ value: UIntMax)

--- a/Source/Range.swift
+++ b/Source/Range.swift
@@ -130,6 +130,18 @@ public class Range/*<Element: ForwardIndexType, Comparable>*/: CustomStringConve
 
 }
 
+extension Range: Equatable {
+
+	public override func equals(_ o: Object!) -> Bool {
+		
+		guard let other = o as? Self else {
+			return false
+		}
+		
+		return (self == other)
+	}
+}
+
 //74138: Silver: constrained type extensions
 /*extension Range where Element == Int32 {
 	#if COCOA 

--- a/Source/Sequence_Extensions.swift
+++ b/Source/Sequence_Extensions.swift
@@ -206,6 +206,11 @@ public extension ISequence /*: ICustomDebugStringConvertible*/ { // 74092: Silve
 		return value
 	}
 
+	public func reversed() -> ISequence<T> {
+		return self.Reverse()
+	}
+
+	@Deprecated
 	public func reverse() -> ISequence<T> {
 		return self.Reverse()
 	}

--- a/Source/Set.swift
+++ b/Source/Set.swift
@@ -48,7 +48,7 @@ __mapped public class Set<T> : ISequence<T> => RemObjects.Elements.System.List<T
 		return NSMutableSet.setWithObjects((&elements[0] as! UnsafePointer<id>), count: length(elements))
 		#endif		
 	}
-
+	
 	/// Create a `Set` from a finite sequence of items.
 	//init<S : SequenceType where T == T>(_ sequence: S) { // Generics not allowed here
 	//}
@@ -257,6 +257,11 @@ __mapped public class Set<T> : ISequence<T> => RemObjects.Elements.System.List<T
 	/// sequence will be ignored.
 	mutating func exclusiveOrInPlace<S : SequenceType where T == T>(sequence: S)*/
 
+	public func subtracting(_ anotherSet: Set<T>) -> Set<T> {
+		return self.subtract(anotherSet)
+	}
+
+	@Deprecated
 	public func subtract(_ anotherSet: Set<T>) -> Set<T> {
 		var result = Set<T>()
 		if (!anotherSet.isEmpty && !self.isEmpty) {
@@ -284,6 +289,11 @@ __mapped public class Set<T> : ISequence<T> => RemObjects.Elements.System.List<T
 	}*/
 	// todo: port others to Sequence as well.
 
+	public func intersection(_ anotherSet: Set<T>) -> Set<T> {
+		return self.intersect(anotherSet)
+	}
+
+	@Deprecated
 	public func intersect(_ anotherSet: Set<T>) -> Set<T> {
 		var result = Set<T>()
 		if (!anotherSet.isEmpty && !self.isEmpty) {
@@ -322,6 +332,16 @@ __mapped public class Set<T> : ISequence<T> => RemObjects.Elements.System.List<T
 			}
 		}
 		return result
+	}
+	
+	public static func + <T>(lhs: Set<T>, rhs: ISequence<T>) -> Set<T> {
+	
+		let targetSet = Set<T>().union(lhs)
+		for element in rhs {
+			targetSet.insert(element)
+		}
+	   
+		return targetSet
 	}
 	
 	//var hashValue: Int { get }


### PR DESCRIPTION
Please note that in Swift, reverse()/subtract()/intersect() are mutable methods that are modifying current instance, instead of yielding a new modified one.

To match Swift3 semantics,   reverse()/subtract()/intersect() has been marked deprecated and their immutable counterparts were added.

Also + overloaded operator added to Set/Array.

And please note the purpose of following added initializer
```swift
// our aggregate operations like .map, .filter will errase our collection type and yield ISequence
// so in order to have consistency with apple swift compiling
// we will do something like [String](fields.map(fieldNameWithRemovedPrivatePrefix)).someArrayFunc
public convenience init(_ sequence: ISequence<T>) {
       return self.init(sequence: sequence)
}
```