### PR TITLE
Minor Array improvements

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -1,4 +1,4 @@
-#if COCOA
+﻿#if COCOA
 typealias PlatformSequence<T> = INSFastEnumeration<T>
 #elseif JAVA
 typealias PlatformSequence<T> = Iterable<T>
@@ -566,10 +566,10 @@ public struct Array<T>
 		//return result
 	//}
 
-	public func enumerated() -> ISequence<(Int, T)> {
+	public func enumerated() -> ISequence<(offset: Int, element: T)> {
 		var index = 0
 		for element in self {
-            __yield (offset: index++, element: element)
+			__yield (offset: index++, element: element)
 		}
 	}
 
@@ -671,11 +671,11 @@ public struct Array<T>
 		#endif
 	}
 
-    func forEach(_ body: (Element) throws -> Void) rethrows {
-        for item in self {
-            try body(item)
-        }
-    }
+	func forEach(_ body: (T) throws -> Void) rethrows {
+		for item in self {
+			try body(item)
+		}
+	}
 
 	/// Call body(p), where p is a pointer to the Array's contiguous storage
 	/*func withUnsafeBufferPointer<R>(body: (UnsafeBufferPointer<T>) -> R) -> R {

--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -671,6 +671,12 @@ public struct Array<T>
 		#endif
 	}
 
+    func forEach(_ body: (Element) throws -> Void) rethrows {
+        for item in self {
+            try body(item)
+        }
+    }
+
 	/// Call body(p), where p is a pointer to the Array's contiguous storage
 	/*func withUnsafeBufferPointer<R>(body: (UnsafeBufferPointer<T>) -> R) -> R {
 	}

--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -1,4 +1,4 @@
-﻿#if COCOA
+#if COCOA
 typealias PlatformSequence<T> = INSFastEnumeration<T>
 #elseif JAVA
 typealias PlatformSequence<T> = Iterable<T>
@@ -569,7 +569,7 @@ public struct Array<T>
 	public func enumerated() -> ISequence<(Int, T)> {
 		var index = 0
 		for element in self {
-			__yield (index++, element)
+            __yield (offset: index++, element: element)
 		}
 	}
 


### PR DESCRIPTION
Added `Array.forEach(_:)` as requested in issue #11, and enabled the use of dot syntax when accessing the offset and element in `Array.enumerated()`.